### PR TITLE
Button-Component: Clean-up

### DIFF
--- a/libs/hiraya/src/components/Button/Button.stories.tsx
+++ b/libs/hiraya/src/components/Button/Button.stories.tsx
@@ -27,6 +27,6 @@ export const IconButton: Story = {
     variants: 'primary',
     buttonSizes: 'small',
     isFullWidth: false,
-    icon: <FileDownloadIcon />,
+    icon: <FileDownloadIcon fontSize="small" />,
   },
 };

--- a/libs/hiraya/src/components/Button/Button.stories.tsx
+++ b/libs/hiraya/src/components/Button/Button.stories.tsx
@@ -18,7 +18,7 @@ export const Demo: Story = {
     label: 'Button',
     variants: 'primary',
     buttonSizes: 'small',
-    isFullWidth: false,
+    isFullWidth: true,
   },
 };
 

--- a/libs/hiraya/src/components/Button/index.tsx
+++ b/libs/hiraya/src/components/Button/index.tsx
@@ -1,6 +1,6 @@
 import { ButtonProps, ButtonStyled } from './style';
 
-const Button: React.FC<ButtonProps> = ({ label, icon, focus, ...props }) => {
+const Button: React.FC<ButtonProps> = ({ label, icon, ...props }) => {
   const renderContent = () => {
     return icon ? icon : label;
   };

--- a/libs/hiraya/src/components/Button/index.tsx
+++ b/libs/hiraya/src/components/Button/index.tsx
@@ -1,6 +1,6 @@
 import { ButtonProps, ButtonStyled } from './style';
 
-const Button: React.FC<ButtonProps> = ({ label, icon, ...props }) => {
+const Button: React.FC<ButtonProps> = ({ label, icon, focus, ...props }) => {
   const renderContent = () => {
     return icon ? icon : label;
   };

--- a/libs/hiraya/src/components/Button/style.ts
+++ b/libs/hiraya/src/components/Button/style.ts
@@ -18,11 +18,12 @@ interface ButtonProps {
 }
 
 const ButtonStyled = styled(MUIButton)<ButtonProps>(
-  ({ variants, buttonSizes, isFullWidth, icon, disabled }) => ({
+  ({ variants = 'primary', buttonSizes, isFullWidth, icon, disabled }) => ({
     ...buttonSizeStyle[buttonSizes || 'large'],
-    ...focusStyle,
+    ...focusStyle(variants),
 
     '&.MuiButton-root': {
+      minWidth: icon && '48px',
       width: isFullWidth ? '100%' : buttonSizeStyle[buttonSizes || 'large'],
     },
 
@@ -34,10 +35,6 @@ const ButtonStyled = styled(MUIButton)<ButtonProps>(
 
     cursor: 'pointer',
     transition: 'background-color 0.3s ease',
-
-    '&:hover': {
-      backgroundColor: variantStyle[variants || 'primary'].hoverBackground,
-    },
   }),
 );
 

--- a/libs/hiraya/src/components/Button/style.ts
+++ b/libs/hiraya/src/components/Button/style.ts
@@ -1,6 +1,6 @@
 import { Button as MUIButton, styled } from '@mui/material';
 
-import { variantStyle, buttonSizeStyle } from './theme';
+import { variantStyle, buttonSizeStyle, disabledState } from './theme';
 import { ReactNode } from 'react';
 
 interface ButtonProps {
@@ -10,15 +10,20 @@ interface ButtonProps {
   isFullWidth?: boolean;
   icon?: ReactNode;
   focus?: boolean;
+  disabled?: boolean;
 }
 
 const ButtonStyled = styled(MUIButton)<ButtonProps>(
-  ({ variants, buttonSizes, isFullWidth, icon, focus }) => ({
-    ...variantStyle[variants || 'primary'],
+  ({ variants, buttonSizes, isFullWidth, icon, focus, disabled }) => ({
     ...buttonSizeStyle[buttonSizes || 'large'],
+
     '&.MuiButton-root': {
       width: isFullWidth ? '100%' : buttonSizeStyle[buttonSizes || 'large'],
     },
+
+    ...(disabled
+      ? { ...disabledState }
+      : { ...variantStyle[variants || 'primary'] }),
 
     borderRadius: '5px',
 

--- a/libs/hiraya/src/components/Button/style.ts
+++ b/libs/hiraya/src/components/Button/style.ts
@@ -13,21 +13,14 @@ interface ButtonProps {
 
 const ButtonStyled = styled(MUIButton)<ButtonProps>(
   ({ variants, buttonSizes, isFullWidth, icon }) => ({
-    backgroundColor: variantStyle[variants || 'primary'].background,
-    color: variantStyle[variants || 'primary'].text,
-    padding: '0',
+    ...variantStyle[variants || 'primary'],
 
     '&.MuiButton-root': {
-      minWidth: icon
-        ? buttonSizeStyle[buttonSizes || 'large']
-        : isFullWidth
-        ? '112px'
-        : '92px',
-      height: buttonSizeStyle[buttonSizes || 'large'],
+      ...buttonSizeStyle[buttonSizes || 'large'],
     },
 
     borderRadius: '5px',
-    border: variantStyle[variants || 'primary'].border,
+
     cursor: 'pointer',
     transition: 'background-color 0.3s ease',
     '&:hover': {

--- a/libs/hiraya/src/components/Button/style.ts
+++ b/libs/hiraya/src/components/Button/style.ts
@@ -9,20 +9,26 @@ interface ButtonProps {
   buttonSizes?: keyof typeof buttonSizeStyle;
   isFullWidth?: boolean;
   icon?: ReactNode;
+  focus?: boolean;
 }
 
 const ButtonStyled = styled(MUIButton)<ButtonProps>(
-  ({ variants, buttonSizes, isFullWidth, icon }) => ({
+  ({ variants, buttonSizes, isFullWidth, icon, focus }) => ({
     ...variantStyle[variants || 'primary'],
-
+    ...buttonSizeStyle[buttonSizes || 'large'],
     '&.MuiButton-root': {
-      ...buttonSizeStyle[buttonSizes || 'large'],
+      width: isFullWidth ? '100%' : buttonSizeStyle[buttonSizes || 'large'],
     },
 
     borderRadius: '5px',
 
     cursor: 'pointer',
     transition: 'background-color 0.3s ease',
+
+    '&:focus': {
+      boxShadow: '0 0 10px 5px #a9b7ea',
+      backgroundColor: variantStyle[variants || 'primary'].hoverBackground,
+    },
     '&:hover': {
       backgroundColor: variantStyle[variants || 'primary'].hoverBackground,
     },

--- a/libs/hiraya/src/components/Button/style.ts
+++ b/libs/hiraya/src/components/Button/style.ts
@@ -1,6 +1,11 @@
 import { Button as MUIButton, styled } from '@mui/material';
 
-import { variantStyle, buttonSizeStyle, disabledState } from './theme';
+import {
+  variantStyle,
+  buttonSizeStyle,
+  disabledState,
+  focusStyle,
+} from './theme';
 import { ReactNode } from 'react';
 
 interface ButtonProps {
@@ -9,13 +14,13 @@ interface ButtonProps {
   buttonSizes?: keyof typeof buttonSizeStyle;
   isFullWidth?: boolean;
   icon?: ReactNode;
-  focus?: boolean;
   disabled?: boolean;
 }
 
 const ButtonStyled = styled(MUIButton)<ButtonProps>(
-  ({ variants, buttonSizes, isFullWidth, icon, focus, disabled }) => ({
+  ({ variants, buttonSizes, isFullWidth, icon, disabled }) => ({
     ...buttonSizeStyle[buttonSizes || 'large'],
+    ...focusStyle,
 
     '&.MuiButton-root': {
       width: isFullWidth ? '100%' : buttonSizeStyle[buttonSizes || 'large'],
@@ -30,10 +35,6 @@ const ButtonStyled = styled(MUIButton)<ButtonProps>(
     cursor: 'pointer',
     transition: 'background-color 0.3s ease',
 
-    '&:focus': {
-      boxShadow: '0 0 10px 5px #a9b7ea',
-      backgroundColor: variantStyle[variants || 'primary'].hoverBackground,
-    },
     '&:hover': {
       backgroundColor: variantStyle[variants || 'primary'].hoverBackground,
     },

--- a/libs/hiraya/src/components/Button/theme.tsx
+++ b/libs/hiraya/src/components/Button/theme.tsx
@@ -1,7 +1,7 @@
 const variantStyle = {
   primary: {
     background: '#305EFF',
-    text: 'white',
+    color: 'white',
     border: 'none',
     hoverBackground: '#2950DA',
   },
@@ -20,9 +20,18 @@ const variantStyle = {
 };
 
 const buttonSizeStyle = {
-  small: '32px !important',
-  medium: '36px  !important',
-  large: '48px  !important',
+  small: {
+    padding: '6px 4px',
+    fontSize: '10px',
+  },
+  medium: {
+    padding: '8px 10px',
+    fontSize: '16px',
+  },
+  large: {
+    padding: '10px 16px',
+    fontSize: '20px',
+  },
 };
 
 export { variantStyle, buttonSizeStyle };

--- a/libs/hiraya/src/components/Button/theme.tsx
+++ b/libs/hiraya/src/components/Button/theme.tsx
@@ -20,6 +20,12 @@ const variantStyle = {
   },
 };
 
+const focusStyle = {
+  '&:focus': {
+    boxShadow: '0 0 10px 5px #a9b7ea',
+  },
+};
+
 const disabledState = {
   background: '#E0E0E0',
   color: '#93a8f1',
@@ -41,4 +47,4 @@ const buttonSizeStyle = {
   },
 };
 
-export { variantStyle, buttonSizeStyle, disabledState };
+export { variantStyle, buttonSizeStyle, disabledState, focusStyle };

--- a/libs/hiraya/src/components/Button/theme.tsx
+++ b/libs/hiraya/src/components/Button/theme.tsx
@@ -8,6 +8,7 @@ const variantStyle = {
   secondary: {
     background: '#FFFFF',
     color: '#305EFF',
+
     border: '1px solid #305EFF',
     hoverBackground: '#b4bdec',
   },
@@ -17,6 +18,12 @@ const variantStyle = {
     border: 'none',
     hoverBackground: '#9E9E9E',
   },
+};
+
+const disabledState = {
+  background: '#E0E0E0',
+  color: '#93a8f1',
+  border: 'none',
 };
 
 const buttonSizeStyle = {
@@ -34,4 +41,4 @@ const buttonSizeStyle = {
   },
 };
 
-export { variantStyle, buttonSizeStyle };
+export { variantStyle, buttonSizeStyle, disabledState };

--- a/libs/hiraya/src/components/Button/theme.tsx
+++ b/libs/hiraya/src/components/Button/theme.tsx
@@ -3,28 +3,34 @@ const variantStyle = {
     background: '#305EFF',
     color: 'white',
     border: 'none',
-    hoverBackground: '#2950DA',
+    '&:hover': {
+      background: '#2950DA',
+    },
   },
   secondary: {
     background: '#FFFFF',
     color: '#305EFF',
-
     border: '1px solid #305EFF',
-    hoverBackground: '#b4bdec',
+    '&:hover': {
+      background: '#b4bdec',
+    },
   },
   tertiary: {
     background: '#BDBDBD',
     color: '#333333',
     border: 'none',
-    hoverBackground: '#9E9E9E',
+    '&:hover': {
+      background: '#9E9E9E',
+    },
   },
 };
 
-const focusStyle = {
+const focusStyle = (variants: keyof typeof variantStyle) => ({
   '&:focus': {
     boxShadow: '0 0 10px 5px #a9b7ea',
+    background: variantStyle[variants || 'primary']['&:hover'].background,
   },
-};
+});
 
 const disabledState = {
   background: '#E0E0E0',

--- a/libs/hiraya/src/components/Button/theme.tsx
+++ b/libs/hiraya/src/components/Button/theme.tsx
@@ -7,13 +7,13 @@ const variantStyle = {
   },
   secondary: {
     background: '#FFFFF',
-    text: '#305EFF',
+    color: '#305EFF',
     border: '1px solid #305EFF',
-    hoverBackground: '#9FA8DA',
+    hoverBackground: '#b4bdec',
   },
   tertiary: {
     background: '#BDBDBD',
-    text: '#333333',
+    color: '#333333',
     border: 'none',
     hoverBackground: '#9E9E9E',
   },


### PR DESCRIPTION
~ Clean-up style.ts
   * Removed focus and hover in style and moved it to theme
   * Put the hover under variantsStyle
   * brought back the minWidth property here because the icon would not change its width when changing buttonsizes
   check this video to see what i mean
   

https://github.com/kmcommitdaily/hiraya-ui/assets/115208064/1410633e-06e6-4be5-b028-cf605a006d68


